### PR TITLE
Changes for issue #5 : Code separation

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -122,6 +122,11 @@ nav {
   height: 100%;
   font-size: 120%; }
 
+#pythonLibCode {
+  width: 100%;
+  height: 100%;
+  font-size: 120%; }
+
 .dialogWindow .selectRobot {
   max-height: 60vh;
   display: flex;

--- a/public/index.html
+++ b/public/index.html
@@ -51,6 +51,7 @@
       <ul class="panelTabs">
         <li id="navBlocks" class="active">Blocks</li>
         <li id="navPython">Python</li>
+        <li id="libPython">library.py</li>
         <li id="navSim">Simulator</li>
       </ul>
       <div class="menuBar">
@@ -81,6 +82,10 @@
         <div id="pythonCode"></div>
       </div>
 
+      <div class="panel" aria-labelledby="libPython">
+        <div id="pythonLibCode"></div>
+      </div>
+      
       <div class="panel" aria-labelledby="navSim">
         <canvas id="renderCanvas" touch-action="none"></canvas>
         <div class="runSim"><span class="icon-play"></span></div>
@@ -153,6 +158,7 @@
   <script src="js/babylon.js?v=1599921990"></script>
   <script src="js/blocklyPanel.js?v=1599921990"></script>
   <script src="js/pythonPanel.js?v=1599921990"></script>
+  <script src="js/pythonLibPanel.js?v=1599921990"></script>
   <script src="js/simPanel.js?v=1599921990"></script>
   <script src="js/main.js?v=1599921990"></script>
 

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -364,6 +364,8 @@ var main = new function() {
         {html: i18n.get('#main-save_blocks#'), line: true, callback: self.saveToComputer},
         {html: i18n.get('#main-load_python#'), line: false, callback: self.loadPythonFromComputer},
         {html: i18n.get('#main-save_python#'), line: true, callback: self.savePythonToComputer},
+        {html: i18n.get('#main-load_python_lib#'), line: false, callback: self.loadPythonLibFromComputer},
+        {html: i18n.get('#main-save_python_lib#'), line: true, callback: self.savePythonLibToComputer},
         {html: i18n.get('#main-export_zip#'), line: true, callback: self.saveZipToComputer},
       ];
 
@@ -375,9 +377,12 @@ var main = new function() {
   this.newProgram = function() {
     confirmDialog(i18n.get('#main-start_new_warning#'), function() {
       blockly.loadDefaultWorkspace();
+      pythonPanel.loadPythonFromBlockly();
+      pythonPanel.saveLocalStorage();  
       pythonPanel.modified = false;
       localStorage.setItem('pythonModified', false);
       blocklyPanel.setDisable(false);
+      pythonLibPanel.editor.setValue('', 0);
     });
   };
 
@@ -395,6 +400,13 @@ var main = new function() {
     } else {
       zip.file('gearsPython.py', blockly.generator.genCode());
     }
+    var py_lib_code = pythonLibPanel.editor.getValue()
+    if (py_lib_code.trim() === "") {
+      // empty library code panel, do nothing
+    } else {
+      zip.file('library.py', py_lib_code);
+    }
+      
     zip.file('gearsRobot.json', JSON.stringify(robot.options, null, 2));
 
     zip.generateAsync({type:'base64'})
@@ -484,14 +496,54 @@ var main = new function() {
     hiddenElement.addEventListener('change', function(e){
       var reader = new FileReader();
       reader.onload = function() {
-        pythonPanel.editor.setValue(this.result, 1);
+        // second arg: 0 replace all, -1 start, 1 end
+        // this used to be 1, I think 0 is more appropriate
+        pythonPanel.editor.setValue(this.result, 0);
         self.tabClicked('navPython');
         pythonPanel.warnModify();
+      };
+      reader.onerror = function() {
+        console.log(reader.error);
       };
       reader.readAsText(e.target.files[0]);
       let filename = e.target.files[0].name.replace(/.py/, '');
       self.$projectName.val(filename);
       self.saveProjectName();
+    });
+  };
+
+  // save library.py to computer
+  this.savePythonLibToComputer = function() {
+    let filename = 'library'
+    let code = null;
+    code = pythonLibPanel.editor.getValue();
+    var hiddenElement = document.createElement('a');
+    hiddenElement.href = 'data:text/x-python;base64,' + btoa(code);
+    hiddenElement.target = '_blank';
+    hiddenElement.download = filename + '.py';
+    hiddenElement.dispatchEvent(new MouseEvent('click'));
+  };
+
+  // load library.py from computer
+  this.loadPythonLibFromComputer = function() {
+    // console.log('starting load of library.py');
+    var hiddenElement = document.createElement('input');
+    hiddenElement.type = 'file';
+    hiddenElement.accept = 'text/x-python,.py';
+    hiddenElement.dispatchEvent(new MouseEvent('click'));
+    hiddenElement.addEventListener('change', function(e){
+      var reader = new FileReader();
+      reader.onload = function() {
+        // console.log('read library.py text:');
+        // console.log(this.result);
+        // second arg: 0 replace all, -1 start, 1 end
+        pythonLibPanel.editor.setValue(this.result, 0);
+        self.tabClicked('libPython');
+      };
+      reader.onerror = function() {
+        console.log(reader.error);
+      };
+      reader.readAsText(e.target.files[0]);
     });
   };
 
@@ -516,6 +568,8 @@ var main = new function() {
         return blocklyPanel;
       } else if (nav == 'navPython') {
         return pythonPanel;
+      } else if (nav == 'libPython') {
+        return pythonLibPanel;
       } else if (nav == 'navSim') {
         return simPanel;
       }

--- a/public/js/msg.js
+++ b/public/js/msg.js
@@ -338,6 +338,12 @@ let MSGS = {
     en: 'Save Python to your computer',
     fr: 'Télécharge le script Python',
   },
+  '#main-load_python_lib#': {
+    en: 'Load library.py from your computer',
+  },
+  '#main-save_python_lib#': {
+    en: 'Save library.py to your computer',
+  },
   '#main-export_zip#': {
     en: 'Export zip package to your computer',
     fr: 'Exporter une archive zip',

--- a/public/js/pythonLibPanel.js
+++ b/public/js/pythonLibPanel.js
@@ -1,0 +1,128 @@
+// This code started as a copy of pythonPanel.js
+// It might be a good idea to go back and look at sharing code between them.
+var pythonLibPanel = new function() {
+  var self = this;
+
+  this.unsaved = false;
+  this.modified = false;
+
+  // Run on page load
+  this.init = function() {
+    self.$save = $('.savePython');
+
+    self.updateTextLanguage();
+
+    self.$save.click(self.save);
+
+    self.loadPythonEditor();
+  };
+
+  // Update text already in html
+  this.updateTextLanguage = function() {
+    self.$save.text(i18n.get('#python-save#'));
+  };
+  
+  // Runs when panel is made active
+  this.onActive = function() {
+    if (self.modified == false) {
+      // self.loadPythonFromBlockly();
+    }
+  };
+
+  // Load ace editor
+  this.loadPythonEditor = function() {
+    let langTools = ace.require("ace/ext/language_tools");
+    self.editor = ace.edit('pythonLibCode');
+    self.editor.setTheme('ace/theme/monokai');
+    self.editor.session.setMode('ace/mode/python');
+    self.editor.setOptions({
+      enableBasicAutocompletion: true,
+      enableSnippets: false,
+      enableLiveAutocompletion: true
+    });
+
+    var staticWordCompleter = {
+      getCompletions: function(editor, session, pos, prefix, callback) {
+        var wordList = [
+          'reflected_light_intensity', 'color', 'color_name', 'rgb', 'hsv', 'red', 'green', 'blue',
+          'angle', 'rate', 'reset',
+          'distance_centimeters',
+          'position', 'x', 'y', 'altitude',
+          'on_for_degrees', 'on_for_rotations', 'on_for_seconds', 'on', 'off'
+        ];
+        var list = wordList.map(function(word) {
+          return {
+            caption: word,
+            value: word,
+            meta: 'method'
+          };
+        })
+        callback(null, list);
+      }
+    };
+    langTools.addCompleter(staticWordCompleter);
+
+    self.loadLocalStorage();
+
+    self.editor.on('change', self.warnModify);
+
+    setInterval(self.saveLocalStorage, 15 * 1000);
+  };
+
+  // Warn when changing python code
+  this.warnModify = function() {
+    // TODO - not clear what to do about warnings for modifying python library
+    if (self.blocklyModified) {
+      return;
+    }
+    self.unsaved = true;
+    self.showSave();
+
+    if (! self.modified) {
+      acknowledgeDialog({
+        title: i18n.get('#python-warning#'),
+        message: i18n.get('#python-cannot_change_back_warning#')
+      });
+      self.modified = true;
+    }
+  };
+
+  // Save to local storage
+  this.saveLocalStorage = function() {
+    if (self.unsaved) {
+      self.unsaved = false;
+      self.hideSave();
+      localStorage.setItem('pythonLibCode', self.editor.getValue());
+      localStorage.setItem('pythonLibModified', self.modified);
+    }
+  };
+
+  // Load from local storage
+  this.loadLocalStorage = function() {
+    var code = localStorage.getItem('pythonLibCode');
+    if (code) {
+      self.editor.setValue(code);
+    }
+    if (localStorage.getItem('pythonLibModified') == 'true') {
+      self.modified = true;
+    }
+  };
+
+  // Save
+  this.save = function() {
+    self.saveLocalStorage();
+  };
+
+  // Hide save button
+  this.hideSave = function() {
+    self.$save.addClass('hide');
+  };
+
+  // Show save button
+  this.showSave = function() {
+    self.$save.removeClass('hide');
+  };
+}
+
+// Init class
+pythonLibPanel.init();

--- a/public/js/skulpt.js
+++ b/public/js/skulpt.js
@@ -76,6 +76,13 @@ var skulpt = new function() {
       './ev3dev2/sensor/virtual.py': 'ev3dev2/sensor/virtual.py?v=1599921990',
       './simPython.js': 'js/simPython.js?v=1599921990'
     }
+    if (filename === "./library.py") {
+      // special case for importing code from the Python Library tab
+      var code = pythonLibPanel.editor.getValue()
+      // console.log('importing lib code.  code follows...')
+      // console.log(code)
+      return code
+    }
     if (Sk.builtinFiles === undefined || Sk.builtinFiles["files"][filename] === undefined) {
       if (filename in externalLibs) {
         return Sk.misceval.promiseToSuspension(


### PR DESCRIPTION
This branch implements a single additional panel, "library.py", which contains python library code.
Use by:

- define stuff in the library.py panel
- import library.py in the main python panel and use your definitions

library.py gets added to the zip file on export if it has any content.

I added Load/Save library.py menu items to the File menu, these work as expected.
I considered adding an 'Import Zip Package' menu item, but haven't yet looked at what to do about the xml and json files...

It would probably be better to have many python panels with different filenames, but that would have made the UI more complicated, so this is a first step.  