### PR TITLE
add pen.setColor and pen.setWidth blocks to blockly interface

### DIFF
--- a/public/customBlocks.json
+++ b/public/customBlocks.json
@@ -1311,5 +1311,49 @@
   "colour": 20,
   "tooltip": "",
   "helpUrl": ""
+},
+{
+  "type": "penSetColor",
+  "message0": "set the pen color to red %1 green %2 blue %3",
+  "args0": [
+    {
+      "type": "input_value",
+      "name": "red",
+      "check": "Number"
+    },
+    {
+      "type": "input_value",
+      "name": "green",
+      "check": "Number"
+    },
+    {
+      "type": "input_value",
+      "name": "blue",
+      "check": "Number"
+    }
+  ],
+  "inputsInline": true,
+  "previousStatement": null,
+  "nextStatement": null,
+  "colour": 20,
+  "tooltip": "",
+  "helpUrl": ""
+},
+{
+  "type": "penSetWidth",
+  "message0": "set the pen width to %1",
+  "args0": [
+    {
+      "type": "input_value",
+      "name": "width",
+      "check": "Number"
+    }
+  ],
+  "inputsInline": true,
+  "previousStatement": null,
+  "nextStatement": null,
+  "colour": 20,
+  "tooltip": "",
+  "helpUrl": ""
 }
 ]

--- a/public/js/ev3dev2_generator.js
+++ b/public/js/ev3dev2_generator.js
@@ -30,6 +30,8 @@ var ev3dev2_generator = new function() {
     Blockly.Python['addPen'] = self.addPen;
     Blockly.Python['penDown'] = self.penDown;
     Blockly.Python['penUp'] = self.penUp;
+    Blockly.Python['penSetColor'] = self.penSetColor;
+    Blockly.Python['penSetWidth'] = self.penSetWidth;
   };
 
   // Generate python code
@@ -537,6 +539,20 @@ var ev3dev2_generator = new function() {
   
   this.penUp = function(block) {
     var code = 'pen.up()\n';
+    return code;
+  };
+
+  this.penSetColor = function(block) {
+    var value_red = Blockly.Python.valueToCode(block, 'red', Blockly.Python.ORDER_ATOMIC);
+    var value_green = Blockly.Python.valueToCode(block, 'green', Blockly.Python.ORDER_ATOMIC);
+    var value_blue = Blockly.Python.valueToCode(block, 'blue', Blockly.Python.ORDER_ATOMIC);
+    var code = 'pen.setColor(' + value_red + ', ' + value_green + ', ' + value_blue + ')\n';
+    return code;
+  };
+
+  this.penSetWidth = function(block) {
+    var value_width = Blockly.Python.valueToCode(block, 'width', Blockly.Python.ORDER_ATOMIC);
+    var code = 'pen.setWidth(' + value_width + ')\n';
     return code;
   };
   

--- a/public/js/pybricks_generator.js
+++ b/public/js/pybricks_generator.js
@@ -30,6 +30,8 @@ var pybricks_generator = new function() {
     Blockly.Python['addPen'] = self.addPen;
     Blockly.Python['penDown'] = self.penDown;
     Blockly.Python['penUp'] = self.penUp;
+    Blockly.Python['penSetColor'] = self.penSetColor;
+    Blockly.Python['penSetWidth'] = self.penSetWidth;
   };
 
   // Generate python code
@@ -565,6 +567,20 @@ var pybricks_generator = new function() {
   
   this.penUp = function(block) {
     var code = 'pen.up()\n';
+    return code;
+  };
+
+  this.penSetColor = function(block) {
+    var value_red = Blockly.Python.valueToCode(block, 'red', Blockly.Python.ORDER_ATOMIC);
+    var value_green = Blockly.Python.valueToCode(block, 'green', Blockly.Python.ORDER_ATOMIC);
+    var value_blue = Blockly.Python.valueToCode(block, 'blue', Blockly.Python.ORDER_ATOMIC);
+    var code = 'pen.setColor(' + value_red + ', ' + value_green + ', ' + value_blue + ')\n';
+    return code;
+  };
+
+  this.penSetWidth = function(block) {
+    var value_width = Blockly.Python.valueToCode(block, 'width', Blockly.Python.ORDER_ATOMIC);
+    var code = 'pen.setWidth(' + value_width + ')\n';
     return code;
   };
 

--- a/public/toolbox.xml
+++ b/public/toolbox.xml
@@ -168,12 +168,36 @@
       </value>
     </block>
   </category>
-  <category name="Pen (Experimental)" colour="#5ba58c">
+  <category name="Pen (Experimental)" colour="#a5745b">
     <block type="addPen">
     </block>
     <block type="penUp">
     </block>
     <block type="penDown">
+    </block>
+    <block type="penSetColor">
+      <value name="red">
+        <shadow type="math_number">
+          <field name="NUM">0</field>
+        </shadow>
+      </value>
+      <value name="green">
+        <shadow type="math_number">
+          <field name="NUM">0</field>
+        </shadow>
+      </value>
+      <value name="blue">
+        <shadow type="math_number">
+          <field name="NUM">0.5</field>
+        </shadow>
+      </value>
+    </block>
+    <block type="penSetWidth">
+      <value name="width">
+        <shadow type="math_number">
+          <field name="NUM">1</field>
+        </shadow>
+      </value>
     </block>
   </category>
   <category name="#blk-control#" colour="#9fa55b">


### PR DESCRIPTION
Make the blockly interface to the pen more like the python interface by adding set pen color and set pen width blocks.