### PR TITLE
Merge code-sep-2 scss changes back into scss after regression.

### DIFF
--- a/scss/main.scss
+++ b/scss/main.scss
@@ -83,8 +83,21 @@ nav {
       color: #999999;
       cursor: pointer;
       user-select: none;
-    }
+      white-space:nowrap;
 
+      .py-mod-controls {
+        display: none;
+
+        span {
+          padding: 0px;
+        }
+      }
+    }
+    
+    li.active .py-mod-controls {
+      display: inline;
+    }
+    
     li:hover {
       background: #E4F0FE;
     }
@@ -171,6 +184,10 @@ nav {
   font-size: 120%;
 }
 
+.pythonModule {
+  width: 100%;
+  height: 100%;
+  font-size: 120%; }
 
 .dialogWindow {
   .selectRobot {


### PR DESCRIPTION
This fixes a bug (issue #42) that occurred between commits 7d4e89 and 811a30 which
caused python module tabs to fail to show the editor.

Diagnosis of bug: The original code-sep-2 PR put these changes into main.css
but main.css is generated from main.scss.  So, the changes persisted until
there was a change to main.scss, at which time a new version of main.css got
generated, and we lost the changes from code-sep-2.  By adding them to
main.scss, they will be put into all new generated versions of main.css.

( @QuirkyCort : Note that this PR doesn't include changes to main.css.  A commit with a newly generated version of main.css is necessary to actually fix the bug.  I think I'm using a different sass than you are, so I'm going to let you make the new main.css, as it will result in fewer changes to that file in the commit.  I did test with my local generated main.css, and it does fix the problem.)