### PR TITLE
fix: translation fix at Wait until block

### DIFF
--- a/public/js/msg.js
+++ b/public/js/msg.js
@@ -1059,7 +1059,7 @@ let MSGS = {
   },
   '#blk-wait_until#': {
     en: 'Wait until',
-    ru: 'ждать, пока',
+    ru: 'ждать до',
     hu: 'Várj, amíg',
   },
   '#blk-button#': {


### PR DESCRIPTION
Small change at Wait until block translation. Previous translation semanticaly wrong and will mislead students. The new version of the translation shows that the program will pause until the specified condition is NOT true.