### PR TITLE
Option to load zip file from computer

### DIFF
--- a/TODO
+++ b/TODO
@@ -15,7 +15,6 @@ Features
 - Prevent jumping over wall when backing up. (Increasing wall friction doesn't work...)
 - Set duty_cycle_sp. Useful for aligning to wall.
 - Buttons
-- Load zip file
 - Touch sensor extendable touch surface
 - Switch to monaco?
 - Add support for Lego Python?

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -585,7 +585,7 @@ var main = new function() {
             .then(function(zip) {
               loadFile(zip, 'meta.json')
               .then(function(metaParams) {
-                let {projName, pythonModified} = JSON.parse(metaParams);
+                let {name: projName, pythonModified} = JSON.parse(metaParams);
                 pythonPanel.modified = pythonModified; //
                 self.$projectName.val(projName);
                 self.saveProjectName();

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -608,6 +608,7 @@ var main = new function() {
                 .then(function(pythonCode) {
                   if (relativePath.endsWith('.py') && relativePath !== 'gearsPython.py') {
                   const moduleName = relativePath.slice(0, -3);
+                  // load into new tab, or overwrite existing tab
                   var moduleSpan = $(`.pythonModule .name-edit:contains('${moduleName}')`)
                   if(moduleSpan.length == 0) {
                     self.addPythonModule(moduleName)
@@ -615,6 +616,7 @@ var main = new function() {
                   var moduleSpan = $(`.pythonModule .name-edit:contains('${moduleName}')`)
                   var moduleID = moduleSpan.closest('.pythonModule').attr('id');
                   pythonLibPanel = self.pyModuleId2Panel[moduleID];
+                  pythonLibPanel.modified = true;
                   pythonLibPanel.editor.setValue(pythonCode, 0);
                   }});
                 });

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -628,8 +628,6 @@ var main = new function() {
         console.log('No file selected.');
       }
     });
-
-    hiddenElement.click();
   };
   
   // save to computer

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -569,13 +569,14 @@ var main = new function() {
   };
 
 
-  this.loadZipFromComputer = function(callback) {
-    var fileInput = document.createElement('input');
-    fileInput.type = 'file';
-    fileInput.accept = '.zip';
-
-    fileInput.addEventListener('change', function(event) {
-      var file = event.target.files[0];
+  this.loadZipFromComputer = function() {
+    // TODO: add automatic importing of additional python modules
+    var hiddenElement = document.createElement('input');
+    hiddenElement.type = 'file';
+    hiddenElement.accept = '.zip';
+    hiddenElement.dispatchEvent(new MouseEvent('click'));
+    hiddenElement.addEventListener('change', function(e){
+      var file = e.target.files[0];
       if (file) {
         var reader = new FileReader();
 
@@ -589,10 +590,7 @@ var main = new function() {
               loadFile(zip, 'gearsPython.py')
               .then(function(pythonCode) {
                 pythonPanel.editor.setValue(pythonCode, 1);
-                self.tabClicked('navPython');
-                pythonPanel.warnModify();
-                // let filename = 'gearsPython.py'.replace(/\.py/, '');
-              })
+              });
               loadFile(zip, 'gearsRobot.json')
               .then(function(robotConf) {
                 self.loadRobot(robotConf)
@@ -604,21 +602,24 @@ var main = new function() {
                 self.$projectName.val(projName);
                 self.saveProjectName();
               });
-              // loadPythonModuleFromComputer
-  //                 // Load Python modules
-  //                 loadedData.pythonModules = {};
-  //                 const pyModulePromises = [];
-  //                 zip.forEach(function (relativePath, zipEntry) {
-  //                   if (relativePath.endsWith('.py') && relativePath !== 'gearsPython.py') {
-  //                     pyModulePromises.push(zipEntry.async('text').then(function (moduleCode) {
-  //                       const moduleName = relativePath.slice(0, -3);
-  //                       loadedData.pythonModules[moduleName] = moduleCode;
-  //                     }));
-  //                   }
+              // // Load Python modules
+              // zip.forEach(function (relativePath, zipEntry) {
+              //   if (relativePath.endsWith('.py') && relativePath !== 'gearsPython.py') {
+              //     pyModulePromises.push(zipEntry.async('text').then(function (moduleCode) {
+              //       pythonLibPanel.editor.setValue(moduleCode, 0);
+              //       pythonLibPanel.moduleName = moduleName;
+              //       // and change the name on the tab
+              //       selector = "nav li#" + moduleID;
+              //       moduleTabEls = $(selector);
+              //       nameSpanEls = moduleTabEls.find('span.name-edit');
+              //       nameSpanEls[0].innerText = moduleName;
+              //     }));
+              //   }
+              // });
             })
             .catch(function(err) {
-              console.error('JSZip error (step 4):', err);
-              alert('Failed to load zip with JSZip (step 4).');
+              console.error('JSZip error:', err);
+              alert('Failed to load zip with JSZip');
             });
         };
 
@@ -642,7 +643,7 @@ var main = new function() {
       }
     });
 
-    fileInput.click();
+    hiddenElement.click();
   };
   
   // save to computer

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -602,8 +602,6 @@ var main = new function() {
                 self.$projectName.val(projName);
                 self.saveProjectName();
               });
-              // TODO: consider adding Python modules loading
-
             })
             .catch(function(err) {
               console.error('JSZip error:', err);

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -570,7 +570,6 @@ var main = new function() {
 
 
   this.loadZipFromComputer = function() {
-    // TODO: add automatic importing of additional python modules
     var hiddenElement = document.createElement('input');
     hiddenElement.type = 'file';
     hiddenElement.accept = '.zip';
@@ -603,6 +602,22 @@ var main = new function() {
                 pythonPanel.editor.setValue(pythonCode, 1);
                 pythonPanel.modified = modifyOrig;
               });
+              // Load Python modules
+              zip.forEach(function (relativePath, zipEntry) {
+                loadFile(zip, relativePath)
+                .then(function(pythonCode) {
+                  if (relativePath.endsWith('.py') && relativePath !== 'gearsPython.py') {
+                  const moduleName = relativePath.slice(0, -3);
+                  var moduleSpan = $(`.pythonModule .name-edit:contains('${moduleName}')`)
+                  if(moduleSpan.length == 0) {
+                    self.addPythonModule(moduleName)
+                  };
+                  var moduleSpan = $(`.pythonModule .name-edit:contains('${moduleName}')`)
+                  var moduleID = moduleSpan.closest('.pythonModule').attr('id');
+                  pythonLibPanel = self.pyModuleId2Panel[moduleID];
+                  pythonLibPanel.editor.setValue(pythonCode, 0);
+                  }});
+                });
               loadFile(zip, 'gearsRobot.json')
               .then(function(robotConf) {
                 self.loadRobot(robotConf)

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -583,24 +583,29 @@ var main = new function() {
         reader.onload = function(e) {
           JSZip.loadAsync(e.target.result)
             .then(function(zip) {
+              loadFile(zip, 'meta.json')
+              .then(function(metaParams) {
+                let {projName, pythonModified} = JSON.parse(metaParams);
+                pythonPanel.modified = pythonModified; //
+                self.$projectName.val(projName);
+                self.saveProjectName();
+              });
               loadFile(zip, 'gearsBlocks.xml')
                 .then(function(xmlText) {
                   blockly.loadXmlText(xmlText);
                 })
               loadFile(zip, 'gearsPython.py')
               .then(function(pythonCode) {
+                // update the python code, and warn user if 
+                // loaded code is modified WRT loaded blocks
+                let modifyOrig = pythonPanel.modified;
+                pythonPanel.modified = !pythonPanel.modified;
                 pythonPanel.editor.setValue(pythonCode, 1);
+                pythonPanel.modified = modifyOrig;
               });
               loadFile(zip, 'gearsRobot.json')
               .then(function(robotConf) {
                 self.loadRobot(robotConf)
-              });
-              loadFile(zip, 'meta.json')
-              .then(function(metaParams) {
-                let {projName, pythonModified} = metaParams;
-                pythonPanel.modified = pythonModified;
-                self.$projectName.val(projName);
-                self.saveProjectName();
               });
             })
             .catch(function(err) {

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -602,20 +602,8 @@ var main = new function() {
                 self.$projectName.val(projName);
                 self.saveProjectName();
               });
-              // // Load Python modules
-              // zip.forEach(function (relativePath, zipEntry) {
-              //   if (relativePath.endsWith('.py') && relativePath !== 'gearsPython.py') {
-              //     pyModulePromises.push(zipEntry.async('text').then(function (moduleCode) {
-              //       pythonLibPanel.editor.setValue(moduleCode, 0);
-              //       pythonLibPanel.moduleName = moduleName;
-              //       // and change the name on the tab
-              //       selector = "nav li#" + moduleID;
-              //       moduleTabEls = $(selector);
-              //       nameSpanEls = moduleTabEls.find('span.name-edit');
-              //       nameSpanEls[0].innerText = moduleName;
-              //     }));
-              //   }
-              // });
+              // TODO: consider adding Python modules loading
+
             })
             .catch(function(err) {
               console.error('JSZip error:', err);

--- a/public/js/msg.js
+++ b/public/js/msg.js
@@ -1661,6 +1661,18 @@ let MSGS = {
     hu: 'ZIP csomag letöltése',
     it: 'Esportare il pacchetto zip sul computer',
   },
+  '#main-import_zip#': {
+    en: 'Import zip package from your computer',
+    fr: 'Importer une archive zip',
+    el: 'Φορτώστε το αρχείο zip από τον υπολογιστή σας',
+    nl: 'Importeer een zip-bestand van uw computer',
+    de: 'Importieren eine zip Datei von Ihrem Computer',
+    pt: 'Importar arquivo ZIP',
+    he: 'יבא קובץ ZIP מהמחשב',
+    ru: 'Импортировать zip-архив',
+    hu: 'ZIP csomag feltöltése',
+    it: 'Importa il pacchetto zip dal tuo computer'
+  },
   '#main-start_new_warning#': {
     en: 'Starting a new program will cause all unsaved work to be lost.',
     fr: 'Commencer un nouveau programme fera perdre tout le travail non sauvegardé.',

--- a/public/js/msg.js
+++ b/public/js/msg.js
@@ -1656,7 +1656,7 @@ let MSGS = {
     nl: 'Exporteer zip bestand naar de computer',
     de: 'Exportiere eine zip Datei auf deinen Computer',
     pt: 'Exportar arquivo ZIP',
-    he: 'יצא קובץ ZIP למחשב',
+    he: 'ZIP שמור קובץ',
     ru: 'Экспортировать zip-архив',
     hu: 'ZIP csomag letöltése',
     it: 'Esportare il pacchetto zip sul computer',
@@ -1668,7 +1668,7 @@ let MSGS = {
     nl: 'Importeer een zip-bestand van uw computer',
     de: 'Importieren eine zip Datei von Ihrem Computer',
     pt: 'Importar arquivo ZIP',
-    he: 'יבא קובץ ZIP מהמחשב',
+    he: 'ZIP טען קובץ',
     ru: 'Импортировать zip-архив',
     hu: 'ZIP csomag feltöltése',
     it: 'Importa il pacchetto zip dal tuo computer'


### PR DESCRIPTION
Adding option to load zip file from computer; to resolve #18 .
Tested with two simple exported zip files, on Firefox, Chrome & Edge.

Note:
- Doesn't load additional python modules, beyond the main script.
- Warns user if loaded python script is modified WRT loaded blocks, by raising the "python cannot be converted back into blocks!" message. Maybe deserves a dedicated warning message?