### PR TITLE
Add sensor visibility for pen traces and paintball splatters.

### DIFF
--- a/public/js/configurator.js
+++ b/public/js/configurator.js
@@ -1081,6 +1081,11 @@ var configurator = new function() {
           type: 'intText',
           help: 'Time-To-Live in milliseconds for the paint splatter. After this duration, the paint splatter will be removed. Set a negative number to last forever. Leave blank to use default.'
         },
+        {
+          option: 'splatterVisibleToSensors',
+          type: 'boolean',
+          help: 'If true, the paint splatter will be visible to color and camera sensors.'
+        },
       ]
     },
     {
@@ -1231,7 +1236,8 @@ var configurator = new function() {
         position: [0, 5, 0],
         rotation: [0, 0, 0],
         options: {
-          doubleSided: false
+          doubleSided: false,
+          traceVisibleToSensors: false
         }
       },
       optionsConfigurations: [
@@ -1247,6 +1253,11 @@ var configurator = new function() {
           option: 'doubleSided',
           type: 'boolean',
           help: 'If true, the drawn trace will be visible from both sides.'
+        },
+        {
+          option: 'traceVisibleToSensors',
+          type: 'boolean',
+          help: 'If true, the drawn trace will be visible to color and camera sensors.'
         }
       ]
     },


### PR DESCRIPTION
Implements #41

Additionally

1. Fixed a bug in PaintballLauncherActuator where all splatter materials were being created with the same name ('paintSplatter'). This caused all splatters to incorrectly use the texture of the last material in the array. The fix ensures each material gets a unique name ('paintSplatter' + i).
2. Corrected 3-digit hex color codes for paintballs to the standard 6-digit format. This prevents potential material cache misses and improves code consistency, although it did not cause a visual bug due to a forgiving helper function.